### PR TITLE
feat(bot): add pointer mismatch and resolution checks

### DIFF
--- a/src/systemInfo.ts
+++ b/src/systemInfo.ts
@@ -8,6 +8,7 @@
  * For a full copy of the LGPL and ethical contribution guidelines, please refer to the `COPYRIGHT.md` and `NOTICE.md` files.
  */
 import { SystemInfo} from './types.js';
+import Bowser from './bowser/bowser.js';
 import { detectIncognito } from './incognito.js';
 import { getMockSystemInfo } from './mock.js';
 import { detectAdBlockers } from './adblocker.js';
@@ -97,6 +98,30 @@ export function detectBot(): { isBot: boolean; signals: string[]; confidence: nu
 
     if (navigator.hardwareConcurrency < 2 || navigator.hardwareConcurrency > 32) {
         signals.push('weak:unusual-concurrency');
+    }
+
+    // CSS pointer/hover and screen resolution checks for desktop OS
+    let isDesktop = false;
+    try {
+        const parsed = Bowser.parse(navigator.userAgent);
+        isDesktop = parsed.platform?.type === 'desktop';
+    } catch {
+        isDesktop = /Linux|Windows|Macintosh|X11/.test(navigator.userAgent) && !/Android|iPhone|iPad|iPod/.test(navigator.userAgent);
+    }
+
+    if (isDesktop) {
+        if (window.matchMedia) {
+            const hoverNone = window.matchMedia('(hover: none)').matches;
+            const pointerNone = !window.matchMedia('(pointer: fine)').matches && !window.matchMedia('(pointer: coarse)').matches;
+            if (hoverNone || pointerNone) {
+                signals.push('strong:desktop-no-pointer-hover-mismatch');
+            }
+        }
+        if (window.screen) {
+            if (window.screen.width === 800 && window.screen.height === 600) {
+                signals.push('medium:desktop-default-headless-resolution');
+            }
+        }
     }
 
     // Calculate confidence score

--- a/test/e2e/cypress/e2e/unit/core.cy.js
+++ b/test/e2e/cypress/e2e/unit/core.cy.js
@@ -49,4 +49,50 @@ describe('core system modules', () => {
       expect(vpn.vpn).to.have.property('probability');
     });
   });
+
+  it('detects bot characteristics', () => {
+    cy.loadFingerprintOSS().then((fp) => {
+      const result = fp.detectBot();
+      expect(result).to.be.ok;
+      expect(result.isBot).to.be.a('boolean');
+      expect(result.signals).to.be.an('array');
+      expect(result.confidence).to.be.a('number');
+    });
+  });
+
+  it('detects desktop pointer/hover mismatch bot signal', () => {
+    cy.visit('/');
+    cy.window().then((win) => {
+      Object.defineProperty(win.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
+        configurable: true
+      });
+      cy.stub(win, 'matchMedia').callsFake((query) => {
+        if (query === '(hover: none)') return { matches: true };
+        if (query === '(pointer: fine)') return { matches: false };
+        if (query === '(pointer: coarse)') return { matches: false };
+        return { matches: false };
+      });
+
+      const result = win.fingerprintOSS.detectBot();
+      expect(result.signals).to.include('strong:desktop-no-pointer-hover-mismatch');
+    });
+  });
+
+  it('detects desktop headless resolution bot signal', () => {
+    cy.visit('/');
+    cy.window().then((win) => {
+      Object.defineProperty(win.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
+        configurable: true
+      });
+      Object.defineProperty(win, 'screen', {
+        value: { width: 800, height: 600 },
+        configurable: true
+      });
+
+      const result = win.fingerprintOSS.detectBot();
+      expect(result.signals).to.include('medium:desktop-default-headless-resolution');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/unit/hash-serialization.cy.js
+++ b/test/e2e/cypress/e2e/unit/hash-serialization.cy.js
@@ -16,11 +16,16 @@ describe('hashing and serialization', () => {
   it('serializes output to JSON', () => {
     cy.loadFingerprintOSS().then((fp) => {
       return fp.getSystemInfo().then((info) => {
-        return fp.fetchGeolocationInfo().then((geo) => {
-          return fp.generateJSON(geo, info, 0.5).then((result) => {
-            expect(result).to.be.ok;
-            expect(result).to.have.property('hash');
-          });
+        const geoMock = {
+          ipAddress: '127.0.0.1',
+          country: { isoCode: 'US', name: 'United States' },
+          city: { name: 'New York', geonameId: 5128581 },
+          location: { accuracyRadius: 10, latitude: 40.7128, longitude: -74.0060, timeZone: 'America/New_York' },
+          traits: { isAnonymous: false, isAnonymousProxy: false, isAnonymousVpn: false, network: '127.0.0.1/32' }
+        };
+        return fp.generateJSON(geoMock, info, 0.5).then((result) => {
+          expect(result).to.be.ok;
+          expect(result).to.have.property('hash');
         });
       });
     });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add pointer/hover mismatch and headless resolution bot-detection signals to `detectBot`
- Adds Bowser-based UA parsing to `detectBot` in [systemInfo.ts](https://github.com/IntegerAlex/fingerprint-oss/pull/99/files#diff-25cd34baad078d80c182583dc37e7b4f2e7399d002dfb541bae4b1744f54ee2d) to classify desktop environments (with a regex fallback if parsing fails).
- On desktop, checks for missing pointer/hover capabilities via `matchMedia`; records `strong:desktop-no-pointer-hover-mismatch` if `(hover: none)` is true or neither `(pointer: fine)` nor `(pointer: coarse)` matches.
- On desktop, checks for an 800×600 screen resolution and records `medium:desktop-default-headless-resolution` if matched.
- Both new signals feed into the existing confidence aggregation, affecting the returned `signals` array, `confidence` score, and `isBot` boolean.
- Adds e2e tests covering both new signals and fixes the JSON serialization test to use an inline geo mock instead of calling `fetchGeolocationInfo()`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized bacc322.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->